### PR TITLE
Update pypi-publish to correct version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
         python -m twine check dist/*
 
     - name: Build and publish
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This action uses a different way of specifying the version, so updating it to the correct way.