### PR TITLE
Add get_manifest method to Manifester object

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -13,7 +13,6 @@ from manifester.settings import settings
 class Manifester:
     def __init__(self, manifest_category, allocation_name=None, **kwargs):
         self.allocation_name = allocation_name or "".join(random.sample(string.ascii_letters, 10))
-        # self.manifest_name = kwargs.get("manifest_name")
         self.offline_token = kwargs.get("offline_token", settings.offline_token)
         manifest_data = settings.manifest_category.get(manifest_category)
         self.subscription_data = manifest_data.subscription_data
@@ -188,6 +187,7 @@ class Manifester:
 
     def trigger_manifest_export(self):
         headers = {"headers": {"Authorization": f"Bearer {self.access_token}"}}
+        limit_exceeded = False
         # Should this use the XDG Base Directory Specification?
         local_file = Path(f"manifests/{self.allocation_name}_manifest.zip")
         local_file.parent.mkdir(parents=True, exist_ok=True)
@@ -236,3 +236,12 @@ class Manifester:
         )
         local_file.write_bytes(manifest.content)
         return manifest
+
+    def get_manifest(self):
+        self.create_subscription_allocation()
+        for sub in self.subscription_data:
+            self.process_subscription_pools(
+                subscription_pools=self.subscription_pools,
+                subscription_data=sub,
+            )
+        return self.trigger_manifest_export()

--- a/manifester/settings.py
+++ b/manifester/settings.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from wsgiref import validate
 
 from dynaconf import Dynaconf
 from dynaconf import Validator
@@ -13,7 +14,6 @@ if "MANIFESTER_DIRECTORY" in os.environ:
         MANIFESTER_DIRECTORY = envar_location
 
 settings_path = MANIFESTER_DIRECTORY.joinpath("manifester_settings.yaml")
-
 validators = [
     Validator("offline_token", must_exist=True),
     Validator("simple_content_access", default="enabled"),
@@ -21,4 +21,7 @@ validators = [
 settings = Dynaconf(
     settings_file=str(settings_path.absolute()),
     ENVVAR_PREFIX_FOR_DYNACONF="MANIFESTER",
+    validators=validators,
 )
+
+settings.validators.validate()

--- a/manifester/settings.py
+++ b/manifester/settings.py
@@ -1,7 +1,6 @@
 import os
-from pathlib import Path
-from wsgiref import validate
 
+from pathlib import Path
 from dynaconf import Dynaconf
 from dynaconf import Validator
 


### PR DESCRIPTION
This commit adds a method to the Manifester class that performs all
steps necessary to return a manifest archive based on
manifester_settings.yaml. This should enable Robottelo
tests/fixtures/helpers to instantiate a Manifester object and
subsequently generate a manifest with a single method call. I have
tested this in the test_positive_create test in
tests/foreman/api/test_subscription.py, and the test passed:
```
org = entities.Organization().create()
manifester = Manifester(manifest_category='golden_ticket')
with manifester.get_manifest() as manifest:
    upload_manifest(org.id, manifest.content)
```

This PR also implements Dynaconf validators for manifester settings,
which were previously commented out.