### PR TITLE
Add delete method to Manifester class

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -67,6 +67,20 @@ class Manifester:
         )
         return self.allocation_uuid
 
+    def delete_subscription_allocation(self):
+        self._access_token = None
+        data = {
+            "headers": {"Authorization": f"Bearer {self.access_token}"},
+            "proxies": self.manifest_data.get("proxies", settings.proxies),
+            "params": {"force": "true"},
+        }
+        response = simple_retry(
+            requests.delete,
+            cmd_args=[f"{self.manifest_data.url.allocations}/{self.allocation_uuid}"],
+            cmd_kwargs=data,
+        )
+        return response
+
     @property
     def subscription_pools(self):
         if not self._subscription_pools:


### PR DESCRIPTION
This commit adds a new method to the manifester class,
delete_subscription_allocation. This is necessary to prevent a buildup
of subscription allocations in RHSM accounts and to ensure that
subscriptions are not consumed by subscription allocations after those
allocations are no longer needed. Note that the first step in this
method is `self._access_token = None` because access tokens are only
valid for 5 minutes. Since it is likely that allocations will need to be
deleted more than five minutes after they are created, this step ensures
that a fresh, valid access token is passed with the DELETE request.