### PR TITLE
Add basic context manager functionality

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -323,3 +323,13 @@ class Manifester:
                 subscription_data=sub,
             )
         return self.trigger_manifest_export()
+
+    def __enter__(self):
+        try:
+            return self.get_manifest()
+        except:
+            self.delete_subscription_allocation()
+            raise
+
+    def __exit__(self, *tb_args):
+        self.delete_subscription_allocation()


### PR DESCRIPTION
This change adds a basic content manager that creates the manifest on enter and deletes the allocation on exit.
This can certainly be beefed up!