### PR TITLE
Add support for external configuration

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -12,13 +12,14 @@ from manifester.settings import settings
 
 class Manifester:
     def __init__(self, manifest_category, allocation_name=None, **kwargs):
+        if isinstance(manifest_category, dict):
+            self.manifest_data = manifest_category
+        else:
+            self.manifest_data = settings.manifest_category.get(manifest_category)
         self.allocation_name = allocation_name or "".join(
             random.sample(string.ascii_letters, 10)
         )
-        self.manifest_data = settings.manifest_category.get(manifest_category)
-        self.offline_token = kwargs.get(
-            "offline_token", self.manifest_data.get("offline_token", settings.offline_token)
-        )
+        self.offline_token = kwargs.get("offline_token", self.manifest_data.offline_token)
         self.subscription_data = self.manifest_data.subscription_data
         self.sat_version = kwargs.get("sat_version", self.manifest_data.sat_version)
         self.token_request_data = {


### PR DESCRIPTION
This PR modifies settings.py to accept configuration files beyond
manifester_settings.yaml as input via the FRAMEWORK_DIRECTORY
environment variable. This change assumes that those additional
configuration files will be in yaml format and that all configuration
files in the framework directory should be ingested, but I am open to
modifying this implementation if it seems too Robottelo-centric.