### PR TITLE
Allow adding entitlements from unlimited pools

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -197,7 +197,8 @@ class Manifester:
             f"The following pools are matches for this subscription: {matching}"
         )
         for match in matching:
-            if match["entitlementsAvailable"] > subscription_data["quantity"]:
+            if (match["entitlementsAvailable"] > subscription_data["quantity"] or
+                match["entitlementsAvailable"] == -1):
                 logger.debug(
                     f"Pool {match['id']} is a match for this subscription and has "
                     f"{match['entitlementsAvailable']} entitlements available."


### PR DESCRIPTION
The `rhsatqe` RHSM account contains a pool of Red Hat Beta Access
subscriptions with an unlimited quantity. Because this quantity is
represented as `-1` in the response to an API request for the details of
that pool, Manifester previously failed to add subscriptions from that
pool to the allocations it was creating. This PR enables Manifester to
pull entitlements from subscription pools that contain an unlimited
quantity of entitlements.