### PR TITLE
Add path and filename as attributes of manifest

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -317,6 +317,8 @@ class Manifester:
             f"{local_file}"
         )
         local_file.write_bytes(manifest.content)
+        manifest.path = local_file
+        manifest.filename = f"{self.allocation_name}_manifest.zip"
         return manifest
 
     def get_manifest(self):

--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -318,7 +318,6 @@ class Manifester:
         )
         local_file.write_bytes(manifest.content)
         manifest.path = local_file
-        manifest.filename = f"{self.allocation_name}_manifest.zip"
         return manifest
 
     def get_manifest(self):


### PR DESCRIPTION
Robottelo's CLI subscription upload method requires copying the manifest
to the Satellite's file system before the upload can be performed. This
PR adds the local relative path to the manifest and the filename of the
manifest as instance attributes of the returned manifest object to
facilitate these operations.