### PR TITLE
Sanitize sat_version and handle sat_version errors

### DIFF
--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -21,3 +21,11 @@ def simple_retry(cmd, cmd_args=None, cmd_kwargs=None, max_timeout=240, _cur_time
         time.sleep(_cur_timeout)
         response = simple_retry(cmd, cmd_args, cmd_kwargs, max_timeout, new_wait)
     return response
+
+def process_sat_version(vers):
+    if len(vers) > 8:
+        vers = vers.split('.')
+        vers = vers[:-1]
+        vers[1] = str(int(vers[1]) - 1)
+        vers = ".".join(vers)
+    return vers

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -23,6 +23,11 @@ def simple_retry(cmd, cmd_args=None, cmd_kwargs=None, max_timeout=240, _cur_time
     return response
 
 def process_sat_version(sat_version, valid_sat_versions):
+    """Ensure that the sat_version parameteris properly formatted for the RHSM API"""
+    # The valid values for this parameter from the API's perspective are all 8 characters or less,
+    # e.g. sat-6.11. Some data sources may include a z-stream version (e.g. sat-6.11.0). The 
+    # conditional below assumes that, if the length of sat_version is greated than 8 characters,
+    # it includes a z-stream version that should be removed.
     if len(sat_version) > 8:
         sat_version = sat_version.split('.')
         sat_version = sat_version[:-1]
@@ -31,4 +36,5 @@ def process_sat_version(sat_version, valid_sat_versions):
         sat_version = sat_version.split('.')
         sat_version[1] = str(int(sat_version[1]) - 1)
         sat_version = ".".join(sat_version)
+    assert sat_version in valid_sat_versions
     return sat_version

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -40,10 +40,10 @@ def process_sat_version(sat_version, valid_sat_versions):
         # sat_version values for the 'POST allocations' endpoint until the corresponding Satellite
         # versions are generally available. As of Satellite 6.12, decrementing the Y-stream version
         # by 1 works around this constraint, but the conditional below may need to be modified to
-        # accommodate additional use cases or versioning scheme changes. 
+        # accommodate versioning scheme changes or additional use cases. 
         if sat_version not in valid_sat_versions:
             sat_version = sat_version.split('.')
             sat_version[1] = str(int(sat_version[1]) - 1)
             sat_version = ".".join(sat_version)
-    assert sat_version in valid_sat_versions
+        assert sat_version in valid_sat_versions
     return sat_version

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -23,18 +23,27 @@ def simple_retry(cmd, cmd_args=None, cmd_kwargs=None, max_timeout=240, _cur_time
     return response
 
 def process_sat_version(sat_version, valid_sat_versions):
-    """Ensure that the sat_version parameteris properly formatted for the RHSM API"""
-    # The valid values for this parameter from the API's perspective are all 8 characters or less,
-    # e.g. sat-6.11. Some data sources may include a z-stream version (e.g. sat-6.11.0). The 
-    # conditional below assumes that, if the length of sat_version is greated than 8 characters,
-    # it includes a z-stream version that should be removed.
-    if len(sat_version) > 8:
-        sat_version = sat_version.split('.')
-        sat_version = sat_version[:-1]
-        sat_version = ".".join(sat_version)
+    """Ensure that the sat_version parameter is properly formatted for the RHSM API when creating
+       a subscription allocation with the 'POST allocations' endpoint"""
     if sat_version not in valid_sat_versions:
-        sat_version = sat_version.split('.')
-        sat_version[1] = str(int(sat_version[1]) - 1)
-        sat_version = ".".join(sat_version)
+        # The valid values for the sat_version parameter when creating a subscription allocation
+        # are all 8 characters or less (e.g. 'sat-6.11'). Some data sources may include a Z-stream
+        # version (e.g. 'sat-6.11.0') when retrieving this value from settings. The conditional
+        # below assumes that, if the length of sat_version is greated than 8 characters, it includes
+        # a Z-stream version that should be removed.
+        if len(sat_version) > 8:
+            sat_version = sat_version.split('.')
+            sat_version = sat_version[:-1]
+            sat_version = ".".join(sat_version)
+        # The conditional below assumes that an invalid sat_version with the Z-stream version removed
+        # is a Y-stream version in development. New Y-stream versions are not available as valid 
+        # sat_version values for the 'POST allocations' endpoint until the corresponding Satellite
+        # versions are generally available. As of Satellite 6.12, decrementing the Y-stream version
+        # by 1 works around this constraint, but the conditional below may need to be modified to
+        # accommodate additional use cases or versioning scheme changes. 
+        if sat_version not in valid_sat_versions:
+            sat_version = sat_version.split('.')
+            sat_version[1] = str(int(sat_version[1]) - 1)
+            sat_version = ".".join(sat_version)
     assert sat_version in valid_sat_versions
     return sat_version

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -22,10 +22,13 @@ def simple_retry(cmd, cmd_args=None, cmd_kwargs=None, max_timeout=240, _cur_time
         response = simple_retry(cmd, cmd_args, cmd_kwargs, max_timeout, new_wait)
     return response
 
-def process_sat_version(vers):
-    if len(vers) > 8:
-        vers = vers.split('.')
-        vers = vers[:-1]
-        vers[1] = str(int(vers[1]) - 1)
-        vers = ".".join(vers)
-    return vers
+def process_sat_version(sat_version, valid_sat_versions):
+    if len(sat_version) > 8:
+        sat_version = sat_version.split('.')
+        sat_version = sat_version[:-1]
+        sat_version = ".".join(sat_version)
+    if sat_version not in valid_sat_versions:
+        sat_version = sat_version.split('.')
+        sat_version[1] = str(int(sat_version[1]) - 1)
+        sat_version = ".".join(sat_version)
+    return sat_version

--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -1,6 +1,7 @@
 import random
 import string
 from dynaconf.utils.boxing import DynaBox
+from functools import cached_property
 from pathlib import Path
 
 import requests
@@ -53,7 +54,7 @@ class Manifester:
             self._access_token = token_data["access_token"]
         return self._access_token
     
-    @property
+    @cached_property
     def valid_sat_versions(self):
         headers = {
             "headers": {"Authorization": f"Bearer {self.access_token}"},
@@ -67,8 +68,8 @@ class Manifester:
                 ],
             cmd_kwargs=headers,
             ).json()
-        for dict in sat_versions_response["body"]:
-            valid_sat_versions.append(dict["value"])
+        for ver_dict in sat_versions_response["body"]:
+            valid_sat_versions.append(ver_dict["value"])
         return valid_sat_versions
 
     def create_subscription_allocation(self):
@@ -93,8 +94,8 @@ class Manifester:
             "invalid version" in self.allocation['error'].values()):
             raise ValueError(
                                 f"{self.sat_version} is not a valid version number."
-                                "Versions must be in the form of \"sat-X.Y\". Only released"
-                                "versions of Satellite are accepted."
+                                "Versions must be in the form of \"sat-X.Y\". Current"
+                                f"valid versions are {self.valid_sat_versions}."
                             )
         self.allocation_uuid = self.allocation["body"]["uuid"]
         logger.info(


### PR DESCRIPTION
When creating a subscription allocation, the RHSM API only accepts a string in the form of `sat-X.Y` for the `sat_version` parameter. This PR adds a helper function that will remove the Z-stream version if it is included in the value of the `sat_version` setting. It also adds error handling for errors caused by an invalid `sat_version` during subscription allocation creation.