### PR TITLE
Disable SCA after creating allocation

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -98,6 +98,16 @@ class Manifester:
                                 f"valid versions are {self.valid_sat_versions}."
                             )
         self.allocation_uuid = self.allocation["body"]["uuid"]
+        if self.simple_content_access == "disabled":
+            simple_retry(
+                requests.put,
+                cmd_args=[f"{self.allocations_url}/{self.allocation_uuid}"],
+                cmd_kwargs={
+                    "headers": {"Authorization": f"Bearer {self.access_token}"},
+                    "proxies": self.manifest_data.get("proxies", settings.proxies),
+                    "json": {"simpleContentAccess": "disabled"},
+                },
+            )
         logger.info(
             f"Subscription allocation created with name {self.allocation_name} "
             f"and UUID {self.allocation_uuid}"


### PR DESCRIPTION
The RHSM API does not support disabling Simple Content Access (SCA) on subscription allocations at creation time. This PR adds a check after creating an allocation and, if SCA is disabled in the settings for that allocation, performs another API call to disable SCA on that allocation. The endpoint for disabling SCA requires that the `simpleContentAccess` parameter be passed as JSON data rather than as a URL parameter, hence the use of the `json` parameter where other requests in Manifester use `params`.