### PR TITLE
Fix inability to process long sat_versions

### DIFF
--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -33,7 +33,7 @@ def process_sat_version(sat_version, valid_sat_versions):
         # a Z-stream version that should be removed.
         if len(sat_version) > 8:
             sat_version = sat_version.split('.')
-            sat_version = sat_version[:-1]
+            sat_version = sat_version[0:2]
             sat_version = ".".join(sat_version)
         # The conditional below assumes that an invalid sat_version with the Z-stream version removed
         # is a Y-stream version in development. New Y-stream versions are not available as valid 


### PR DESCRIPTION
Previously, the `process_sat_version` helper method assumed that all Satellite versions would be in the form of X.Y.Z. The most recent release of Satellite 6.11, though, is 6.11.4.1, which demonstrates that this assumption is not valid in all cases. This PR modifies the helper method to account for cases where the Satellite version has more digits than X.Y.Z.