### PR TITLE
Added in directory creation for logging path

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Unit Tests
       run: |
         pip install -U pip
-        # pip install -U .[test]
+        pip install -U .[test]
         cp manifester_settings.yaml.example manifester_settings.yaml
+        manifester --help
         # pytest -v tests/ --ignore tests/functional

--- a/manifester/logger.py
+++ b/manifester/logger.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 import logzero
 
@@ -6,6 +7,7 @@ from manifester.settings import settings
 
 
 def setup_logzero(level="info", path="logs/manifester.log", silent=True):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
     log_fmt = "%(color)s[%(levelname)s %(asctime)s]%(end_color)s %(message)s"
     debug_fmt = (
         "%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]"


### PR DESCRIPTION
This should hopefully solve the issue we're seeing with missing log file path in robottelo's github checks. Though I'm a but dubious as to why the GHA isn't using robottelo's own logs directory..

Also added a call to manifester's cli since no unit tests are currently being ran in checks.