### PR TITLE
Modify content and return value after timeout

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -349,7 +349,8 @@ class Manifester:
                 break
             request_count += 1
         if limit_exceeded:
-            return
+            self.content = None
+            return self
         export_job = export_job.json()
         export_href = export_job["body"]["href"]
         manifest = simple_retry(


### PR DESCRIPTION
This PR expicitly sets manifest.content to `None` and returns the manifest object when a manifest export job times out. This change facilitates the failover to cloned manifests in Robottelo. Previously, failed export jobs triggered an exception in Robottelo when manifester fixtures attempted to upload manifests because, in those cases, the manifest object did not contain a `content` attribute.