### PR TITLE
Add username_prefix to settings and allocation name

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -32,7 +32,9 @@ class Manifester:
 
             self.requester = requests
             self.is_mock = False
-        self.allocation_name = allocation_name or "".join(random.sample(string.ascii_letters, 10))
+        self.allocation_name = allocation_name or f"{settings.username_prefix}-" + "".join(
+            random.sample(string.ascii_letters, 10)
+        )
         self.manifest_name = Path(f"{self.allocation_name}_manifest.zip")
         self.offline_token = kwargs.get("offline_token", self.manifest_data.offline_token)
         self.subscription_data = self.manifest_data.subscription_data

--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -33,7 +33,7 @@ class Manifester:
             self.requester = requests
             self.is_mock = False
         self.allocation_name = allocation_name or f"{settings.username_prefix}-" + "".join(
-            random.sample(string.ascii_letters, 10)
+            random.sample(string.ascii_letters, 8)
         )
         self.manifest_name = Path(f"{self.allocation_name}_manifest.zip")
         self.offline_token = kwargs.get("offline_token", self.manifest_data.offline_token)

--- a/manifester/settings.py
+++ b/manifester/settings.py
@@ -16,6 +16,7 @@ settings_path = MANIFESTER_DIRECTORY.joinpath("manifester_settings.yaml")
 validators = [
     # Validator("offline_token", must_exist=True),
     Validator("simple_content_access", default="enabled"),
+    Validator("username_prefix", len_min=3),
 ]
 settings = Dynaconf(
     settings_file=str(settings_path.absolute()),

--- a/manifester_settings.yaml.example
+++ b/manifester_settings.yaml.example
@@ -2,6 +2,7 @@
 log_level: "info"
 offline_token: ""
 proxies: {"https": ""}
+username_prefix: "example_username"  # replace value with a unique username
 manifest_category:
   golden_ticket:
     # An offline token can be generated at https://access.redhat.com/management/api


### PR DESCRIPTION
This pull request is part of an effort to implement an inventory system for subscription allocations created by Manifester. In situations where multiple different users are creating allocations using the same login on a shared RHSM account, the RHSM API does not provide a means to differentiate which allocations were created by which users. To facilitate such differentiation, this PR adds a `username_prefix` setting that is used in the construction of the allocation name. This should enable syncing the allocations created by individual users to their local inventories while avoiding collisions with allocations created by other users.