### PR TITLE
Add subscription_allocations property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,5 +179,8 @@ mark-parentheses = false
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"
 
+[tool.ruff.lint.pylint]
+max-branches = 16
+
 [tool.ruff.mccabe]
 max-complexity = 20


### PR DESCRIPTION
As part of the Manifester inventory management effort, this PR adds a `subscription_allocations` property (filtered by the `username_prefix` setting)  to the `Manifester` object. To enable this change, it abstracts the paginated API data processing functionaliy from the `subscription_pools` property to a helper function capable of handling GET requests to either the `allocations` or `pools` endpoints.

Additionally, this PR adds a new unit test and mock endpoint to the RhsmApiStub class's `get()` method.