### PR TITLE
Add basic inventory file management

### DIFF
--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -117,9 +117,18 @@ def fetch_paginated_data(manifester, endpoint):
             total_results = len(_endpoint_data["body"])
             logger.debug(f"Total {endpoint} available on this account: {total_results}")
     if endpoint == "allocations":
-        return [
-            a for a in _endpoint_data["body"] if a["name"].startswith(manifester.username_prefix)
-        ]
+        if hasattr(_endpoint_data, "force_export_failure"):
+            return [
+                a
+                for a in _endpoint_data.allocation_data["body"]
+                if a["name"].startswith(manifester.username_prefix)
+            ]
+        else:
+            return [
+                a
+                for a in _endpoint_data["body"]
+                if a["name"].startswith(manifester.username_prefix)
+            ]
     elif endpoint == "pools":
         return _endpoint_data
 

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -86,13 +86,14 @@ def fetch_paginated_data(manifester, endpoint):
             manifester.requester.get,
             cmd_args=[f"{_endpoint_url}"],
             cmd_kwargs=data,
-        ).json()
+        )
         if _endpoint_data.status_code in [400, 401, 403, 404]:
             raise HTTPError(
                 f"Received HTTP {_endpoint_data.status_code} response code. Please "
                 "ensure that the request is a properly-formatted and authorized "
                 "request to a valid endpoint."
             )
+        _endpoint_data = _endpoint_data.json()
         if manifester.is_mock and endpoint == "pools":
             _endpoint_data = _endpoint_data.pool_response
         elif manifester.is_mock and endpoint == "allocations":
@@ -114,13 +115,14 @@ def fetch_paginated_data(manifester, endpoint):
                 manifester.requester.get,
                 cmd_args=[f"{_endpoint_url}"],
                 cmd_kwargs=data,
-            ).json()
+            )
             if offset_data.status_code in [400, 401, 403, 404]:
                 raise HTTPError(
                     f"Received HTTP {_endpoint_data.status_code} response code. Please "
                     "ensure that the request is a properly-formatted and authorized "
                     "request to a valid endpoint."
                 )
+            offset_data = offset_data.json()
             if manifester.is_mock and endpoint == "pools":
                 offset_data = offset_data.pool_response
             elif manifester.is_mock and endpoint == "allocations":
@@ -151,16 +153,14 @@ def load_inventory_file(file):
 
     :return: list of dictionaries
     """
-    if file.suffix in (".yaml", ".yml"):
-        loader = yaml
-        loader_args = {"Loader": yaml.FullLoader}
-        with file.open() as f:
-            return loader.load(f, **loader_args) or []
-    else:
+    if file.suffix not in (".yaml", ".yml"):
         logger.warn(
             f"Found invalid inventory file {file}. Inventory file must exist and "
             "have a .yaml or .yml suffix."
         )
+    else:
+        with file.open() as f:
+            return yaml.load(f, Loader=yaml.FullLoader) or []
 
 
 def update_inventory(inventory_data):

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -1,9 +1,13 @@
 """Defines helper functions used by Manifester."""
 from collections import UserDict
+from pathlib import Path
 import random
 import time
 
 from logzero import logger
+import yaml
+
+from manifester.settings import settings
 
 MAX_RESULTS_PER_PAGE = 50
 RESULTS_LIMIT = 10000
@@ -118,6 +122,34 @@ def fetch_paginated_data(manifester, endpoint):
         ]
     elif endpoint == "pools":
         return _endpoint_data
+
+
+def load_inventory_file(file):
+    """Load local inventory file.
+
+    :return: list of dictionaries
+    """
+    if file.suffix in (".yaml", ".yml"):
+        loader = yaml
+        loader_args = {"Loader": yaml.FullLoader}
+        with file.open() as f:
+            return loader.load(f, **loader_args) or []
+    else:
+        logger.warn(
+            f"Found invalid inventory file {file}. Inventory file must exist and "
+            "have a .yaml or .yml suffix."
+        )
+
+
+def update_inventory(inventory_data):
+    """Replace the existing inventory file with current subscription allocations."""
+    inventory_path = Path(settings.inventory_path)
+    if load_inventory_file(inventory_path):
+        inventory_path.unlink()
+    inventory_path.touch()
+    if inventory_data != []:
+        with inventory_path.open("w") as inventory_file:
+            yaml.dump(inventory_data, inventory_file, allow_unicode=True)
 
 
 def fake_http_response_code(good_codes=None, bad_codes=None, fail_rate=0):

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -5,6 +5,7 @@ import random
 import time
 
 from logzero import logger
+from requests import HTTPError
 import yaml
 
 from manifester.settings import settings
@@ -86,6 +87,12 @@ def fetch_paginated_data(manifester, endpoint):
             cmd_args=[f"{_endpoint_url}"],
             cmd_kwargs=data,
         ).json()
+        if _endpoint_data.status_code in [400, 401, 403, 404]:
+            raise HTTPError(
+                f"Received HTTP {_endpoint_data.status_code} response code. Please "
+                "ensure that the request is a properly-formatted and authorized "
+                "request to a valid endpoint."
+            )
         if manifester.is_mock and endpoint == "pools":
             _endpoint_data = _endpoint_data.pool_response
         elif manifester.is_mock and endpoint == "allocations":
@@ -108,6 +115,12 @@ def fetch_paginated_data(manifester, endpoint):
                 cmd_args=[f"{_endpoint_url}"],
                 cmd_kwargs=data,
             ).json()
+            if offset_data.status_code in [400, 401, 403, 404]:
+                raise HTTPError(
+                    f"Received HTTP {_endpoint_data.status_code} response code. Please "
+                    "ensure that the request is a properly-formatted and authorized "
+                    "request to a valid endpoint."
+                )
             if manifester.is_mock and endpoint == "pools":
                 offset_data = offset_data.pool_response
             elif manifester.is_mock and endpoint == "allocations":

--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -12,7 +12,12 @@ from dynaconf.utils.boxing import DynaBox
 from logzero import logger
 from requests.exceptions import Timeout
 
-from manifester.helpers import fetch_paginated_data, process_sat_version, simple_retry
+from manifester.helpers import (
+    fetch_paginated_data,
+    process_sat_version,
+    simple_retry,
+    update_inventory,
+)
 from manifester.settings import settings
 
 MAX_RESULTS_PER_PAGE = 50
@@ -143,6 +148,7 @@ class Manifester:
             f"Subscription allocation created with name {self.allocation_name} "
             f"and UUID {self.allocation_uuid}"
         )
+        update_inventory(self.subscription_allocations)
         return self.allocation_uuid
 
     def delete_subscription_allocation(self):
@@ -278,6 +284,7 @@ class Manifester:
                             f"{subscription_data['name']} to the allocation."
                         )
                         self._active_pools.append(match)
+                        update_inventory(self.subscription_allocations)
                         break
                 elif add_entitlements.status_code == SUCCESS_CODE:
                     logger.debug(
@@ -285,6 +292,7 @@ class Manifester:
                         f"{subscription_data['name']} to the allocation."
                     )
                     self._active_pools.append(match)
+                    update_inventory(self.subscription_allocations)
                     break
                 else:
                     raise RuntimeError(
@@ -386,3 +394,4 @@ class Manifester:
     def __exit__(self, *tb_args):
         """Deletes subscription allocation on teardown."""
         self.delete_subscription_allocation()
+        update_inventory(self.subscription_allocations)

--- a/manifester_settings.yaml.example
+++ b/manifester_settings.yaml.example
@@ -3,6 +3,7 @@ log_level: "info"
 offline_token: ""
 proxies: {"https": ""}
 username_prefix: "example_username"  # replace value with a unique username
+inventory_path: "manifester_inventory.yaml"
 manifest_category:
   golden_ticket:
     # An offline token can be generated at https://access.redhat.com/management/api

--- a/tests/test_manifester.py
+++ b/tests/test_manifester.py
@@ -13,6 +13,7 @@ manifest_data = {
     "log_level": "debug",
     "offline_token": "test",
     "proxies": {"https": ""},
+    "inventory_path": "manifester_inventory.yaml",
     "username_prefix": "test_user",
     "url": {
         "token_request": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
@@ -151,7 +152,7 @@ class RhsmApiStub(MockStub):
             and not ("export" in args[0] or "pools" in args[0])
             and not self._has_offset
         ):
-            self.allocation_data = "this allocation data also includes entitlement data"
+            self.allocation_data = sub_allocations_response
             return self
         if args[0].endswith("export"):
             self.body = {"exportJobID": "123456", "href": "exportJob"}


### PR DESCRIPTION
This PR adds helper functions to load a local inventory file and to replace the contents of that file. It also adds calls to the update inventory method several times in the course of a manifester run to try to avoid stale data being stored persistently in the inventory file in the event that a manifester run terminates unexpectedly.