### PR TITLE
Make CLI respect log_level setting

### DIFF
--- a/manifester/logger.py
+++ b/manifester/logger.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 import logzero
 
-from manifester.settings import settings
-
 
 def setup_logzero(level="info", path="logs/manifester.log", silent=True):
     """Call logzero setup with the given settings."""
@@ -17,13 +15,10 @@ def setup_logzero(level="info", path="logs/manifester.log", silent=True):
     log_level = getattr(logging, level.upper(), logging.INFO)
     # formatter for terminal
     formatter = logzero.LogFormatter(fmt=debug_fmt if log_level is logging.DEBUG else log_fmt)
-    logzero.setup_default_logger(formatter=formatter, disableStderrLogger=silent)
+    logzero.setup_logger(formatter=formatter, disableStderrLogger=silent)
     logzero.loglevel(log_level)
     # formatter for file
     formatter = logzero.LogFormatter(
         fmt=debug_fmt if log_level is logging.DEBUG else log_fmt, color=False
     )
     logzero.logfile(path, loglevel=log_level, maxBytes=1e9, backupCount=3, formatter=formatter)
-
-
-setup_logzero(level=settings.get("log_level", "info"))

--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -18,7 +18,10 @@ from manifester.helpers import (
     simple_retry,
     update_inventory,
 )
+from manifester.logger import setup_logzero
 from manifester.settings import settings
+
+setup_logzero(level=settings.get("log_level", "info"))
 
 
 class Manifester:


### PR DESCRIPTION
Currently, the manifester CLI writes debug-level log messages to the terminal regardless of the `log_level` setting. This PR imports and runs the `setup_logzero` function from manifester/logger.py to make the CLI write log messages at the level specified in the settings.