### PR TITLE
Create inventory file if absent when loading

### DIFF
--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -154,6 +154,8 @@ def load_inventory_file(file):
 
     :return: list of dictionaries
     """
+    if not file.is_file():
+        file.touch()
     if file.suffix not in (".yaml", ".yml"):
         logger.warn(
             f"Found invalid inventory file {file}. Inventory file must exist and "


### PR DESCRIPTION
This PR fixes an error that occurred when attempting to load the inventory while the inventory file is not present at the `inventory_path` location.