### PR TITLE
Fix syntax error in python-publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         # build/push in lowest support python version
-        python-version: [ 3.10 ]
+        python-version: [ "3.10" ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Manifester's build and publish workflow is failing on the `setup-python` action with the error `The version '3.1' with architecture 'x64' was not found for Ubuntu 22.04.` I am guessing that `3.10` is being interpreted as a float and evaluated to `3.1`. This PR converts the version to a string in the hope that this allows the version number to be evaluated accurately.