### PR TITLE
Use build command instead of setup.py

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         pip install -U pip
         pip install .[setup]
-        python setup.py sdist bdist_wheel
+        python -m build
         python -m twine check dist/*
 
     - name: Build and publish


### PR DESCRIPTION
Manifester's python-publish workflow has been failing during the Setup and Build step. These failures persisted after my previous PR fixing a syntax issue with the version. This PR switches from invoking `setup.py` directly to invoking the `build` tool in an attempt to resolve the error.