### PR TITLE
Add `scripts` section to pyproject.toml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,4 +44,5 @@ jobs:
         pip install -U pip
         pip install -U .[test]
         cp manifester_settings.yaml.example manifester_settings.yaml
+        manifester --help
         pytest -v tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ setup = [
     "twine",
 ]
 
+[project.scripts]
+manifester = "manifester.commands:cli"
+
 [tools.setuptools]
 platforms = ["any"]
 zip-safe = false


### PR DESCRIPTION
When I converted Manifester to pyproject.toml, I did not include a `project.scripts` section. As a result, an executable for the Manifester CLI is not installed when the Manifester package is installed. This PR adds a `project.scripts` section to pyproject.toml so the Manifester CLI is easily accessible.