### PR TITLE
Increase export job check timeout

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -339,7 +339,7 @@ class Manifester:
         Starts the export job, monitors the status of the job, and downloads the manifest on
         successful completion of the job.
         """
-        MAX_REQUESTS = 50
+        MAX_REQUESTS = 500
         SUCCESS_CODE = 200
         data = {
             "headers": {"Authorization": f"Bearer {self.access_token}"},


### PR DESCRIPTION
This PR greatly increases the number of times manifester will check the status of a manifest export job in RHSM before timing out. This is intended to address scenarios in which there is a significant gap between an export job being scheduled in RHSM and the job starting execution.