### PR TITLE
Isolate manifester's logger

### DIFF
--- a/manifester/_settings.py
+++ b/manifester/_settings.py
@@ -1,0 +1,13 @@
+"""Module with settings variables/constants."""
+import os
+from pathlib import Path
+
+settings_file = "manifester_settings.yaml"
+MANIFESTER_DIRECTORY = Path()
+
+if "MANIFESTER_DIRECTORY" in os.environ:
+    envar_location = Path(os.environ["MANIFESTER_DIRECTORY"])
+    if envar_location.is_dir():
+        MANIFESTER_DIRECTORY = envar_location
+
+settings_path = MANIFESTER_DIRECTORY.joinpath(settings_file)

--- a/manifester/commands.py
+++ b/manifester/commands.py
@@ -3,9 +3,9 @@ import os
 from pathlib import Path
 
 import click
-from logzero import logger
 
 from manifester import Manifester, helpers
+from manifester.logger import _logger as logger
 from manifester.settings import settings
 
 

--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -9,15 +9,11 @@ import subprocess
 import sys
 import time
 
-from logzero import logger
 from requests import HTTPError
 import yaml
 
-from manifester.logger import setup_logzero
+from manifester.logger import _logger as logger
 from manifester.settings import settings
-
-setup_logzero(level="info")
-
 
 RESULTS_LIMIT = 10000
 

--- a/manifester/logger.py
+++ b/manifester/logger.py
@@ -1,11 +1,28 @@
 """Defines manifester's internal logging."""
+
 import logging
 from pathlib import Path
 
+from dynaconf import Dynaconf
 import logzero
 
+from manifester._settings import settings_path
 
-def setup_logzero(level="info", path="logs/manifester.log", silent=True):
+# Initialize temporary settings without running the Vault loader
+temp_settings = Dynaconf(
+    settings_file=str(settings_path.absolute()),
+    ENVVAR_PREFIX_FOR_DYNACONF="MANIFESTER",
+    load_dotenv=False,
+)
+
+
+def _setup_logzero(
+    level=temp_settings.get("log_level", "info"),
+    path="logs/manifester.log",
+    name=None,
+    formatter=None,
+    silent=True,
+):
     """Call logzero setup with the given settings."""
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     log_fmt = "%(color)s[%(levelname)s %(asctime)s]%(end_color)s %(message)s"
@@ -15,10 +32,29 @@ def setup_logzero(level="info", path="logs/manifester.log", silent=True):
     log_level = getattr(logging, level.upper(), logging.INFO)
     # formatter for terminal
     formatter = logzero.LogFormatter(fmt=debug_fmt if log_level is logging.DEBUG else log_fmt)
-    logzero.setup_logger(formatter=formatter, disableStderrLogger=silent)
-    logzero.loglevel(log_level)
+    if not name:
+        name = "manifester"
     # formatter for file
     formatter = logzero.LogFormatter(
         fmt=debug_fmt if log_level is logging.DEBUG else log_fmt, color=False
     )
-    logzero.logfile(path, loglevel=log_level, maxBytes=1e9, backupCount=3, formatter=formatter)
+    logger = logzero.setup_logger(
+        name=name,
+        formatter=formatter,
+        level=log_level,
+        logfile=path,
+        maxBytes=1e9,
+        backupCount=3,
+        disableStderrLogger=silent,
+    )
+    return logger
+
+
+_logger = _setup_logzero()
+# delete temporary settings after initializing the logger
+del temp_settings
+
+
+def setup_logzero(level, path, name=None, silent=True):
+    """Call logzero setup with the given settings."""
+    _logger = _setup_logzero(level, path, name, silent)

--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -9,7 +9,6 @@ import random
 import string
 
 from dynaconf.utils.boxing import DynaBox
-from logzero import logger
 from requests.exceptions import Timeout
 
 from manifester.helpers import (
@@ -18,7 +17,7 @@ from manifester.helpers import (
     simple_retry,
     update_inventory,
 )
-from manifester.logger import setup_logzero
+from manifester.logger import _logger as logger
 from manifester.settings import settings
 
 
@@ -33,7 +32,6 @@ class Manifester:
         proxies=None,
         **kwargs,
     ):
-        setup_logzero(level=settings.get("log_level", "info"))
         if minimal_init:
             self.offline_token = settings.get("offline_token")
             self.token_request_url = settings.get("url").get("token_request")

--- a/manifester/settings.py
+++ b/manifester/settings.py
@@ -1,18 +1,9 @@
 """Retrieves settings from configuration file and runs Dynaconf validators."""
-import os
-from pathlib import Path
 
 from dynaconf import Dynaconf, Validator
 
-settings_file = "manifester_settings.yaml"
-MANIFESTER_DIRECTORY = Path()
+from manifester._settings import settings_path
 
-if "MANIFESTER_DIRECTORY" in os.environ:
-    envar_location = Path(os.environ["MANIFESTER_DIRECTORY"])
-    if envar_location.is_dir():
-        MANIFESTER_DIRECTORY = envar_location
-
-settings_path = MANIFESTER_DIRECTORY.joinpath("manifester_settings.yaml")
 validators = [
     Validator("offline_token", must_exist=True),
     Validator("simple_content_access", default="enabled"),


### PR DESCRIPTION
Broker and Manifester both use the default logger, so the last to have their log setup run overrides the other.

This PR isolates the manifester's own logger in its library, but it keeps the possibility to modify the logger from outside using the `setup_logzero` API.