### PR TITLE
Add offline token argument to inventory command

### DIFF
--- a/manifester/commands.py
+++ b/manifester/commands.py
@@ -73,11 +73,12 @@ def delete(allocations, all_, remove_manifest_file):
 @cli.command()
 @click.option("--details", is_flag=True, help="Display full inventory details")
 @click.option("--sync", is_flag=True, help="Fetch inventory data from RHSM before displaying")
-def inventory(details, sync):
+@click.option("--offline-token", type=str, default=None)
+def inventory(details, sync, offline_token):
     """Display the local inventory file's contents."""
     border = "-" * 38
     if sync:
-        helpers.update_inventory(Manifester(minimal_init=True).subscription_allocations)
+        helpers.update_inventory(Manifester(minimal_init=True, offline_token=offline_token).subscription_allocations)
     inv = helpers.load_inventory_file(Path(settings.inventory_path))
     if not details:
         logger.info("Displaying local inventory data")

--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -33,7 +33,10 @@ class Manifester:
         **kwargs,
     ):
         if minimal_init:
-            self.offline_token = settings.get("offline_token")
+            if kwargs.get("offline_token") is not None:
+                self.offline_token = kwargs.get("offline_token")
+            else:
+                self.offline_token = settings.get("offline_token")
             self.token_request_url = settings.get("url").get("token_request")
             self.allocations_url = settings.get("url").get("allocations")
             self._access_token = None


### PR DESCRIPTION
This PR modifies the inventory CLI command to accept an offline_token argument. This should resolve an issue with generating an access token that I'm encountering with a CI pipeline. With this change, the job can pass an environment variable containing the offline token to the Manifester CLI, which mirrors how we access the same token in another CI use case.