### PR TITLE
Return future-dated subscription pools from stage

### DIFF
--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -71,6 +71,8 @@ def fetch_paginated_data(manifester, endpoint):
         MAX_RESULTS_PER_PAGE = 100
     elif endpoint == "pools":
         _endpoint_url = f"{manifester.allocations_url}/{manifester.allocation_uuid}/pools"
+        if "stage" in manifester.allocations_url:
+            _endpoint_url = _endpoint_url + "?future=true"
         _endpoint_data = manifester._subscription_pools
         MAX_RESULTS_PER_PAGE = 50
     else:


### PR DESCRIPTION
This PR modifies the API requests that fetch the list of subscription pools to include future-dated subscriptions when using a stage RHSM account while leaving requests to prod RHSM unchanged.