### PR TITLE
Make max_timeout var in simple_retry helper configurable

### DIFF
--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -18,8 +18,10 @@ from manifester.settings import settings
 RESULTS_LIMIT = 10000
 
 
-def simple_retry(cmd, cmd_args=None, cmd_kwargs=None, max_timeout=240, _cur_timeout=1):
+def simple_retry(cmd, cmd_args=None, cmd_kwargs=None, max_timeout=None, _cur_timeout=1):
     """Re(Try) a function given its args and kwargs up until a max timeout."""
+    if max_timeout is None:
+        max_timeout = settings.get("max_retry_timeout", 240)
     cmd_args = cmd_args if cmd_args else []
     cmd_kwargs = cmd_kwargs if cmd_kwargs else {}
     # If additional debug information is needed, the following log entry can be modified to

--- a/manifester/settings.py
+++ b/manifester/settings.py
@@ -9,6 +9,7 @@ validators = [
     Validator("simple_content_access", default="enabled"),
     Validator("username_prefix", len_min=3),
     Validator("max_export_retries", default=5, is_type_of=int, gt=0),
+    Validator("max_retry_timeout", default=240, is_type_of=int, gt=0),
 ]
 settings = Dynaconf(
     settings_file=str(settings_path.absolute()),

--- a/manifester_settings.yaml.example
+++ b/manifester_settings.yaml.example
@@ -2,6 +2,7 @@
 inventory_path: "manifester_inventory.yaml"
 log_level: "info"
 max_export_retries: 5
+max_retry_timeout: 240
 offline_token: ""
 proxies: {"https": ""}
 url:


### PR DESCRIPTION
We're seeing an issue where [fetch_paginated_data](https://github.com/SatelliteQE/manifester/blob/caa73e4ec8306c2c8406bb110648134215bf7ff7/manifester/helpers.py#L122) is failing on simple_retry with timeout error. This PR adds support to make max_timeout configurable to avoid this issue.