### PR TITLE
Fix response caching for subscription_pools, allocations

### DIFF
--- a/manifester/helpers.py
+++ b/manifester/helpers.py
@@ -141,6 +141,10 @@ def fetch_paginated_data(manifester, endpoint):
             _results = len(offset_data["body"])
             total_results = len(_endpoint_data["body"])
             logger.debug(f"Total {endpoint} available on this account: {total_results}")
+        if endpoint == "allocations":
+            manifester._allocations = _endpoint_data
+        elif endpoint == "pools":
+            manifester._subscription_pools = _endpoint_data
     if endpoint == "allocations":
         if hasattr(_endpoint_data, "force_export_failure"):
             return [


### PR DESCRIPTION
When allocations were introduced, the response caching ended up being broken, causing us to significantly increase our api consumption rates.