### PR TITLE
Initialize allocation_uuid and attached_quantity in __init__

### DIFF
--- a/manifester/manifester.py
+++ b/manifester/manifester.py
@@ -93,6 +93,8 @@ class Manifester:
             self._allocations = None
             self._subscription_pools = None
             self._active_pools = []
+            self.allocation_uuid = None
+            self.attached_quantity = 0
             self.sat_version = process_sat_version(
                 kwargs.get("sat_version", self.manifest_data.sat_version),
                 self.valid_sat_versions,
@@ -178,6 +180,10 @@ class Manifester:
 
     def delete_subscription_allocation(self, uuid=None):
         """Deletes the specified subscription allocation and returns the RHSM API's response."""
+        target_uuid = uuid or self.allocation_uuid
+        if not target_uuid:
+            logger.warning("No allocation UUID available, skipping deletion.")
+            return None
         self._access_token = None
         data = {
             "headers": {"Authorization": f"Bearer {self.access_token}"},
@@ -186,11 +192,11 @@ class Manifester:
         }
         response = simple_retry(
             self.requester.delete,
-            cmd_args=[f"{self.allocations_url}/{uuid if uuid else self.allocation_uuid}"],
+            cmd_args=[f"{self.allocations_url}/{target_uuid}"],
             cmd_kwargs=data,
         )
         update_inventory(
-            self.subscription_allocations, remove=True, uuid=uuid if uuid else self.allocation_uuid
+            self.subscription_allocations, remove=True, uuid=target_uuid
         )
         return response
 


### PR DESCRIPTION
## Summary

- Initialize `allocation_uuid = None` and `attached_quantity = 0` in `__init__` to prevent `AttributeError` on error paths
- Guard `delete_subscription_allocation()` against `None` UUID so cleanup doesn't mask the original API error (e.g. RHSM 502/503)

Closes #71

## Test plan

- [x] Existing tests pass (11/11, excluding long-running retry timeout tests)
- [x] Reproduced bug locally with mock 502 response — `AttributeError` no longer raised, original `JSONDecodeError` surfaces correctly
- [x] `delete_subscription_allocation()` logs warning and returns `None` when no UUID available

🤖 Generated with [Claude Code](https://claude.com/claude-code)